### PR TITLE
Update PentahoGoogleSheetsPluginInputMeta.java

### DIFF
--- a/src/main/java/org/pentaho/di/trans/steps/pentahogooglesheets/PentahoGoogleSheetsPluginInputMeta.java
+++ b/src/main/java/org/pentaho/di/trans/steps/pentahogooglesheets/PentahoGoogleSheetsPluginInputMeta.java
@@ -92,7 +92,7 @@ public class PentahoGoogleSheetsPluginInputMeta extends BaseStepMeta implements 
 	@Injection( name = "worksheetId", group = "SHEET" )
 	private String worksheetId;
 	
-	@Injection( name = "sampleFields", group = "INPUT_Fields" )
+	@Injection( name = "sampleFields", group = "INPUT_FIELDS" )
 	private Integer sampleFields;
 	
 	@InjectionDeep


### PR DESCRIPTION
Input Meta is not working. keep getting this error msg :
java.lang.RuntimeException: Group 'INPUT_Fields' is not defined class org.pentaho.di.trans.steps.pentahogooglesheets.PentahoGoogleSheetsPluginInputMeta
2021/01/15 10:09:55 - class org.pentaho.di.core.injection.bean.BeanInjectionInfo - 	at org.pentaho.di.core.injection.bean.BeanInjectionInfo.addInjectionProperty(BeanInjectionInfo.java:111)
2021/01/15 10:09:55 - class org.pentaho.di.core.injection.bean.BeanInjectionInfo - 	at org.pentaho.di.core.injection.bean.BeanLevelInfo.introspect(BeanLevelInfo.java:88)
2021/01/15 10:09:55 - class org.pentaho.di.core.injection.bean.BeanInjectionInfo - 	at org.pentaho.di.core.injection.bean.BeanLevelInfo.introspect(BeanLevelInfo.java:59)
2021/01/15 10:09:55 - class org.pentaho.di.core.injection.bean.BeanInjectionInfo - 	at org.pentaho.di.core.injection.bean.BeanLevelInfo.init(BeanLevelInfo.java:51)